### PR TITLE
Streamline Documentation & Add Docker Guide

### DIFF
--- a/COMMITERS.csv
+++ b/COMMITERS.csv
@@ -1,3 +1,4 @@
 Name, Email, Github ID
 xxx xxxx, xxx@axmsoftware.com, axmsoftware
 Will Sams, will@samswebs.com, willsams
+David Bakare, bakaredavid007@gmail.com, 3akare

--- a/README.md
+++ b/README.md
@@ -126,68 +126,9 @@ APIS consists of several interconnected software modules that work together seam
 | **📖 [apis-hw-info](https://github.com/SonyCSL/apis-hw-info)** | Hardware Guide | Reference documentation for compatible hardware and technical specifications ([Documentation](https://github.com/hyphae/apis-hw-info/blob/main/MAIN-DOCUMENT_EN.md)) |
 
 ---
-
-## 💻 Installation Guide
-
-![image 2](https://github.com/user-attachments/assets/66de9429-c395-4b02-a015-b4a11e455b1f)
-
-### 🖥️ System Requirements
-
-**Tested Operating Systems:**
-- **Ubuntu**: 18.04, 20.04 ✅
-- **CentOS**: 7, 8 ✅  
-- **macOS**: Catalina, Big Sur ✅
-
-> **⚠️ Important**: Virtual environments are not currently supported.
-
-### 📋 Prerequisites
-
-**Before you start, make sure you have:**
-
-```bash
-# Ubuntu/Debian systems:
-sudo apt update
-sudo apt install git make maven groovy python3-venv python3-pip
-```
-
-**Also Required:**
-- **Java Development Kit (JDK)**: Latest version
-- **Python**: 3.6.9 or later  
-- **SQLite**: 3.8.3 or later (required for CentOS 7)
-
-### 🚀 Installation Steps
-
-**1. Clone the Repository**
-```bash
-git clone https://github.com/hyphae/APIS.git
-cd APIS
-```
-
-**2. Build All Components**
-```bash
-make build
-```
-*This downloads and compiles all necessary software - takes 5-10 minutes*
-
-**3. Start the System**
-```bash
-make run
-```
-
-**4. Verify Installation**
-- Open `http://0.0.0.0:4382/` in your browser
-- You should see the APIS control panel
-- All components should show as "Running" status
-
-### 🔧 Troubleshooting
-
-**If you encounter issues:**
-
-- **"Command not found" errors**: Install all prerequisites first
-- **"make build" or "make run" fails**: Open a new terminal and try again
-- **Port conflicts**: Stop other web servers or restart your computer
-- **Permission issues**: Check file permissions or try with appropriate privileges
-
+## Installation
+- **Docker (Recommended):** See [Docker Setup Guide](docs/INSTALL_DOCKER.md) for quick deployment and troubleshooting.
+- **Native Host:** See [Host Installation](docs/INSTALL_HOST.md) for building directly on your Linux distribution.
 ---
 
 ## 📖 How to Use APIS

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ make run
 ```bash
 make stop
 ```
-
 ---
 
 ## 🛠️ System Components
@@ -125,14 +124,11 @@ APIS consists of several interconnected software modules that work together seam
 | **🚀 [apis-build_version_up_system](https://github.com/hyphae/apis-build_version_up_system)** | Deployment Tool | Automates multi-node software installation and configuration for production systems ([Documentation](https://github.com/hyphae/apis-build_version_up_system/blob/main/doc/en/apis-build_version_up_system_specification_EN.md)) |
 | **📖 [apis-hw-info](https://github.com/SonyCSL/apis-hw-info)** | Hardware Guide | Reference documentation for compatible hardware and technical specifications ([Documentation](https://github.com/hyphae/apis-hw-info/blob/main/MAIN-DOCUMENT_EN.md)) |
 
----
-## Installation
+## 🔩 Installation
 - **Docker (Recommended):** See [Docker Setup Guide](docs/INSTALL_DOCKER.md) for quick deployment and troubleshooting.
 - **Native Host:** See [Host Installation](docs/INSTALL_HOST.md) for building directly on your Linux distribution.
----
 
 ## 📖 How to Use APIS
-
 ### 🎮 Basic Operations
 
 **Start the System:**
@@ -151,7 +147,6 @@ make stop
 ```
 
 ### ⚙️ Configuration
-
 **Energy Trading Setup:**
 1. Access the web interfaces to modify transaction parameters
 2. Adjust energy trading conditions per time window
@@ -163,7 +158,6 @@ make stop
 - Transaction history and analytics
 - Performance metrics and system health
 - Community-wide energy balance reports
-
 ---
 
 ## 🌍 Key Benefits

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # 🔋 APIS - Autonomous Power Interchange System
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hyphae/APIS/badge)](https://scorecard.dev/viewer/?uri=github.com/hyphae/APIS)
 
----
-
 ## 🎯 What is APIS?
 
 **APIS** is an innovative open-source platform that enables **Physical Peer-to-Peer (PP2P) energy sharing** between distributed batteries in microgrids. By leveraging Variable Renewable Energy (VRE) sources, APIS builds resilient microgrids that enhance community self-sufficiency and reduce dependency on traditional centralized power generation.
@@ -18,8 +16,6 @@ Imagine if your home battery could automatically share power with your neighbors
 - **🛡️ Build Resilience**: Keep communities powered during grid outages
 
 Click [here](https://www.sonycsl.co.jp/tokyo/11481/) for more details about the research behind APIS.
-
----
 
 ## 🔧 How It Works
 
@@ -46,8 +42,6 @@ APIS achieves **precise energy sharing between batteries using constant current 
 - 📊 **Custom Parameters**: Configure energy amount, pricing, and timing preferences
 
 ![Autonomous Control Diagram](https://user-images.githubusercontent.com/71874910/95833927-3ff19b80-0d77-11eb-9bc7-1994e641d5fd.PNG)
-
----
 
 ## 🚀 Quick Start (5 Minutes)
 
@@ -90,7 +84,10 @@ make run
 ```bash
 make stop
 ```
----
+
+## 🔩 Installation
+- **Native Host (Recommended for Hardware):** See [Host Installation](docs/INSTALL_HOST.md) for building directly on your Linux distribution.
+- **Docker (Best for evaluation):** See [Docker Setup Guide](docs/INSTALL_DOCKER.md) for quick deployment and troubleshooting.
 
 ## 🛠️ System Components
 
@@ -123,10 +120,6 @@ APIS consists of several interconnected software modules that work together seam
 | **⚙️ [apis-dcdc_batt_comm](https://github.com/hyphae/apis-dcdc_batt_comm)** | Hardware Driver | Controls actual DC/DC converters and batteries (replaces emulator for real deployments) ([Documentation](https://github.com/hyphae/apis-dcdc_batt_comm/blob/master/doc/en/apis-dcdc_batt_comm_specification_en.md)) |
 | **🚀 [apis-build_version_up_system](https://github.com/hyphae/apis-build_version_up_system)** | Deployment Tool | Automates multi-node software installation and configuration for production systems ([Documentation](https://github.com/hyphae/apis-build_version_up_system/blob/main/doc/en/apis-build_version_up_system_specification_EN.md)) |
 | **📖 [apis-hw-info](https://github.com/SonyCSL/apis-hw-info)** | Hardware Guide | Reference documentation for compatible hardware and technical specifications ([Documentation](https://github.com/hyphae/apis-hw-info/blob/main/MAIN-DOCUMENT_EN.md)) |
-
-## 🔩 Installation
-- **Docker (Recommended):** See [Docker Setup Guide](docs/INSTALL_DOCKER.md) for quick deployment and troubleshooting.
-- **Native Host:** See [Host Installation](docs/INSTALL_HOST.md) for building directly on your Linux distribution.
 
 ## 📖 How to Use APIS
 ### 🎮 Basic Operations

--- a/docs/INSTALL_DOCKER.md
+++ b/docs/INSTALL_DOCKER.md
@@ -1,0 +1,134 @@
+## 💻 Docker Installation & Troubleshooting Guide
+
+### 1. Environment Setup
+
+The environment is containerized to ensure consistency and avoid host machine dependency issues. You must map the required ports during the initial run to access the web interfaces later.
+
+1. **Pull the base image:**
+```bash
+docker pull ubuntu:20.04
+
+```
+
+
+2. **Run the container with port mappings:**
+```bash
+docker run -it \
+  -p 10000:10000 \
+  -p 4382:4382 \
+  -p 4390:4390 \
+  -p 8000:8000 \
+  -p 27017:27017 \
+  --name apis-dev \
+  ubuntu:20.04
+
+```
+
+
+3. **Install dependencies:**
+Inside the container shell, install the necessary packages:
+```bash
+apt-get update && apt-get install -y \
+    git \
+    make \
+    maven \
+    groovy \
+    python3-venv \
+    python3-pip \
+    mongodb
+
+```
+
+
+
+### 2. Clone and Build APIS
+
+Clone the main repository which contains the Makefile orchestrator.
+
+1. **Clone the repo:**
+```bash
+git clone https://github.com/hyphae/APIS
+cd APIS
+
+```
+
+
+2. **Build all services:**
+```bash
+make build
+
+```
+
+
+
+### 3. Configuration Fix: Standardize MongoDB Port
+
+To ensure seamless communication, all service configurations were standardized to the default MongoDB port, **27017**, resolving previous discrepancies where some services expected 27018.
+<img width="885" height="296" alt="Image" src="https://github.com/user-attachments/assets/bac792fe-6c90-4ace-b3cf-416edf5d629b" />
+
+### 4. Running the Application Suite
+
+1. **Start services:**
+```bash
+make run
+
+```
+
+
+2. **Verify services:**
+Access the interfaces from your host machine browser:
+* **APIS Web Interface:** `http://localhost:4382`
+* **Emulator Interface:** `http://localhost:4390`
+
+<img width="1765" height="804" alt="Image" src="https://github.com/user-attachments/assets/47157db0-5a09-40b4-8c71-002e42f5d0ef" />
+
+### 5. Persisting the Environment
+
+To save your progress, commit the configured container to a new image from a **new terminal on your host**:
+
+1. **Commit the container:**
+```bash
+docker commit apis-dev hyphae-apis-stable:latest
+
+```
+
+
+2. **Pre-built Image:**
+Alternatively, pull the verified stable image:
+```bash
+docker pull 3akare/hyphaes-stable:latest
+
+```
+
+
+
+---
+
+## ⚠️ Troubleshooting & Known Issues
+
+### 1. Missing Port Mappings (macOS/Linux)
+
+**Problem:** Services run successfully inside the container but `http://localhost:4382` is unreachable from the host.
+**Cause:** Using `docker run` without `-p` flags.
+**Solution:** You must define all ports (`10000, 4382, 4390, 8000, 27017`) at the time of container creation. Docker does not allow adding port mappings to a running container.
+
+### 2. MongoDB Installation Failure (Ubuntu 22.04+)
+
+**Problem:** `E: Package 'mongodb' has no installation candidate`.
+**Cause:** Recent Ubuntu versions (22.04, 24.04) removed `mongodb` from default repos in favor of official MongoDB sources.
+**Solution:** Add the official MongoDB 7.0 repository:
+
+```bash
+curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor
+echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+sudo apt-get update && sudo apt-get install -y mongodb-org
+
+```
+
+### 3. Python Version Incompatibility
+
+**Problem:** `pip` fails when installing `numpy==1.19.4`.
+**Cause:** Ubuntu 24.04 uses Python 3.12. NumPy 1.19.4 is deprecated and incompatible with Python versions > 3.9.
+**Solution:** * **Recommended:** Use the `ubuntu:20.04` Docker image as specified in Section 1, which utilizes Python 3.8.
+
+* **Manual Fix:** Update `apis-emulator/requirements.txt` to use `numpy>=1.26.0` if running on a modern host OS.

--- a/docs/INSTALL_HOST.md
+++ b/docs/INSTALL_HOST.md
@@ -72,5 +72,3 @@ make run
 * **Build/Run Failures:** Environmental variables may not have refreshed; open a new terminal session and retry.
 * **Port Conflicts:** Ensure ports `4382` and `4390` are not occupied by other web services.
 * **Permission Denied:** Ensure your user has write access to the `APIS` directory or use appropriate privileges for system-level dependency installation.
-
-Would you like me to merge these two guides into a single `INSTALL.md` file with a table of contents?

--- a/docs/INSTALL_HOST.md
+++ b/docs/INSTALL_HOST.md
@@ -1,0 +1,76 @@
+## 💻 Native Host Installation Guide
+![image 2](https://github.com/user-attachments/assets/66de9429-c395-4b02-a015-b4a11e455b1f)
+### **1. System Requirements**
+
+The project has been validated across multiple environments. Ensure your host meets these specifications to avoid build failures.
+
+* **Ubuntu:** 18.04, 20.04 ✅
+* **CentOS:** 7, 8 ✅
+* **macOS:** Catalina, Big Sur ✅
+
+> [!IMPORTANT]
+> **Virtual environments are not currently supported.** Native installation must be performed directly on the host OS.
+
+---
+
+### **2. Prerequisites**
+
+Install the core toolchain before attempting the build.
+
+**Debian/Ubuntu Systems:**
+
+```bash
+sudo apt update
+sudo apt install git make maven groovy python3-venv python3-pip
+
+```
+
+**Global Dependencies:**
+
+* **JDK:** Latest version required for Maven builds.
+* **Python:** 3.6.9+ required for the emulator.
+* **SQLite:** 3.8.3+ (Critical for CentOS 7 users).
+
+---
+
+### **3. Installation Steps**
+
+1. **Clone the Repository:**
+```bash
+git clone https://github.com/hyphae/APIS.git
+cd APIS
+
+```
+
+
+2. **Build All Components:**
+The `Makefile` handles the compilation of all internal services. This process typically takes **5-10 minutes**.
+```bash
+make build
+
+```
+
+
+3. **Start the System:**
+```bash
+make run
+
+```
+
+
+4. **Verify Deployment:**
+* **Dashboard:** Navigate to `http://0.0.0.0:4382/`
+* **Status Check:** All components in the APIS control panel should display a **"Running"** status.
+
+
+
+---
+
+### **4. Troubleshooting**
+
+* **Command not found:** Verify that all items in the **Prerequisites** section are in your `$PATH`.
+* **Build/Run Failures:** Environmental variables may not have refreshed; open a new terminal session and retry.
+* **Port Conflicts:** Ensure ports `4382` and `4390` are not occupied by other web services.
+* **Permission Denied:** Ensure your user has write access to the `APIS` directory or use appropriate privileges for system-level dependency installation.
+
+Would you like me to merge these two guides into a single `INSTALL.md` file with a table of contents?


### PR DESCRIPTION
I have restructured the documentation to reduce README clutter and introduce a containerized setup option.

Changes:

- Refactored Installation: Moved the lengthy native host instructions to docs/INSTALL_HOST.md.
- Added Docker Guide: Created docs/INSTALL_DOCKER.md for standardized container testing.
- Simplified README: Replaced walls of text with a clean "Quick Start" and links to the specific guides in docs/.

Reasoning: The README was becoming too large. Separating the guides makes the landing page more readable while providing clear paths for both hardware users (Native) and developers (Docker).