### PR TITLE
fix: resolve apis-bom build failure, apis-bom:3.0.0 not found, JUnit version missing (fixes #74)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ help:
 	@printf "  make stop                   - Stop all APIS services\n"
 
 apis-bom:
-	git clone $(GIT_BASE_URL)/apis-bom.git
+	@[ -d apis-bom ] || git clone $(GIT_BASE_URL)/apis-bom.git
 apis-common:
-	git clone $(GIT_BASE_URL)/apis-common.git
+	@[ -d apis-common ] || git clone $(GIT_BASE_URL)/apis-common.git
 apis-main:
 	git clone $(GIT_BASE_URL)/apis-main.git
 apis-ccc:
@@ -56,7 +56,9 @@ apis-tester:
 
 build-apis-bom: apis-bom
 	cd apis-bom/ && make install
-build-apis-common:apis-common
+apply-apis-common-fix: apis-common
+	cp fixes/apis-common-pom.xml apis-common/pom.xml
+build-apis-common: apply-apis-common-fix
 	cd apis-common/ && make install
 build-apis-main: apis-main
 	cd apis-main/ && make package

--- a/fixes/apis-common-pom.xml
+++ b/fixes/apis-common-pom.xml
@@ -1,0 +1,91 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <vertx.version>4.5.10</vertx.version>
+  </properties>
+
+  <groupId>jp.co.sony.csl.dcoes.apis</groupId>
+  <artifactId>apis-common</artifactId>
+  <version>3.0.0</version>
+
+  <name>APIS COMMON</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>jp.co.sony.csl.dcoes.apis</groupId>
+        <artifactId>apis-bom</artifactId>
+        <version>3.4.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <!-- SLF4J API for logging (required by Vert.x 4) -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.9</version>
+    </dependency>
+    <!-- Logback Classic as SLF4J implementation -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.4.11</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- We specify the Maven compiler plugin as we need to set it to Java 1.8 -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.11.0</version>
+            <configuration>
+            <source>11</source>
+            <target>11</target>
+            <compilerArgs>
+              <arg>-Xlint:deprecation</arg>
+            </compilerArgs>
+            <showDeprecation>true</showDeprecation>
+            <failOnWarning>false</failOnWarning>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <author>true</author>
+            <source>1.8</source>
+            <show>private</show>
+            <encoding>UTF-8</encoding>
+            <charset>UTF-8</charset>
+            <docencoding>UTF-8</docencoding>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>


### PR DESCRIPTION
## Summary

Fixes **#74**: Build fails when Maven tries to pull `apis-bom` during build (`apis-bom:3.0.0` not found in Maven Central).

## Problem

- **Non-resolvable import POM**: `apis-common` imports `jp.co.sony.csl.dcoes.apis:apis-bom:3.0.0` via `${project.version}`, but that BOM is not in Maven Central (it is built and installed locally).
- **Missing JUnit version**: Because the BOM import fails, dependency management is not applied, so `junit:junit` has no version and the build fails with `'dependencies.dependency.version' for junit:junit:jar is missing`.

## Solution

- Use **`apis-bom` version `3.4.1`** in `apis-common`'s `dependencyManagement` instead of `${project.version}` (3.0.0), so the BOM resolved from the local repo matches the installed `apis-bom` and JUnit gets its version from the BOM.
- Add a **`fixes/`** directory with the corrected `apis-common` `pom.xml`.
- Update the **Makefile** to:
  - Apply the fix automatically before building `apis-common` (new `apply-apis-common-fix` target).
  - Clone `apis-bom` and `apis-common` only if the directory is missing, so repeated builds work.

## Changes

- `fixes/apis-common-pom.xml` – `apis-common` POM with `apis-bom` version set to `3.4.1`.
- `Makefile` – Clone-if-missing for `apis-bom` / `apis-common`, `apply-apis-common-fix` target, and `build-apis-common` updated to use it.

## Verification

- `make build-apis-bom` then `make build-apis-common` (or `make build`) completes successfully.
- `apis-common` tests pass (`mvn clean install` in `apis-common/`).

Closes #74.