### PR TITLE
feat: Add Docker support for containerized deployment (#65)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Git - only exclude root .git, keep submodule .git directories
+/.git
+/.github
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+**/venv/
+ENV/
+*.egg-info/
+.eggs/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker files (not needed in container)
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# Logs
+*.log
+logs/
+
+# MongoDB data (will be created fresh in container)
+mongodb/db/*
+!mongodb/db/.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,111 @@
+# APIS - Autonomous Power Interchange System
+# Docker container for running all APIS services
+#
+# Build: docker build -t apis:latest .
+# Run:   docker-compose up
+
+FROM ubuntu:20.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    make \
+    maven \
+    groovy \
+    python3 \
+    python3-venv \
+    python3-pip \
+    openjdk-11-jdk \
+    wget \
+    gnupg \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install MongoDB
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - \
+    && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list \
+    && apt-get update \
+    && apt-get install -y mongodb-org \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set Java environment - detect architecture dynamically
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+    echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" >> /etc/profile.d/java.sh; \
+    else \
+    echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64" >> /etc/profile.d/java.sh; \
+    fi && \
+    echo 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/java.sh
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Create working directory
+WORKDIR /app
+
+# Copy repository files
+COPY . /app/
+
+# Create MongoDB data directory
+RUN mkdir -p /app/mongodb/db /data/db
+
+# Clone and build all APIS components
+# Use bash shell to ensure proper environment
+SHELL ["/bin/bash", "-c"]
+
+# Build apis-bom and apis-common with version 3.0.0 for compatibility with GitHub repos
+# The GitHub repos expect version 3.0.0 in their pom.xml files
+RUN source /etc/profile.d/java.sh && \
+    export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java)))) && \
+    echo "JAVA_HOME is set to: $JAVA_HOME" && \
+    # Patch apis-bom version to 3.0.0
+    sed -i 's|<version>3.4.1</version>|<version>3.0.0</version>|g' /app/apis-bom/pom.xml && \
+    cd /app/apis-bom && mvn install && \
+    # Patch apis-common version to 3.0.0
+    sed -i 's|<version>3.4.1</version>|<version>3.0.0</version>|g' /app/apis-common/pom.xml && \
+    cd /app/apis-common && mvn install && \
+    # Now clone and build remaining components from GitHub
+    cd /app && \
+    git clone https://github.com/hyphae/apis-main.git && \
+    cd apis-main && mvn package -Dmaven.test.skip=true && \
+    cd /app && \
+    git clone https://github.com/hyphae/apis-ccc.git && \
+    cd apis-ccc && mvn package -Dmaven.test.skip=true && \
+    cd /app && \
+    git clone https://github.com/hyphae/apis-log.git && \
+    cd apis-log && mvn package -Dmaven.test.skip=true && \
+    cd /app && \
+    git clone https://github.com/hyphae/apis-web.git && \
+    cd apis-web && mvn package -Dmaven.test.skip=true && \
+    cd /app && \
+    # Python components
+    git clone https://github.com/hyphae/apis-emulator.git && \
+    cd apis-emulator && sh venv.sh && \
+    cd /app && \
+    git clone https://github.com/hyphae/apis-main_controller.git && \
+    cd apis-main_controller && sh venv.sh && \
+    cd /app && \
+    git clone https://github.com/hyphae/apis-service_center.git && \
+    cd apis-service_center && sh venv.sh && sh initdb.sh && \
+    cd /app && \
+    git clone https://github.com/hyphae/apis-tester.git && \
+    cd apis-tester && sh venv.sh
+
+# Expose service ports
+# 4382 - Main Controller
+# 4390 - Hardware Emulator
+# 8000 - Service Center
+# 10000 - Testing Interface
+# 27018 - MongoDB
+EXPOSE 4382 4390 8000 10000 27018
+
+# Copy and set entrypoint script
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+# Set entrypoint
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# APIS Docker Compose Configuration
+# Quick Start: docker-compose up
+#
+# Available Services:
+#   - Main Controller:    http://localhost:4382/
+#   - Hardware Emulator:  http://localhost:4390/
+#   - Service Center:     http://localhost:8000/static/ui_example/staff/visual.html
+#   - Testing Interface:  http://localhost:10000/
+#   - MongoDB:            localhost:27018
+
+services:
+  apis:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: apis
+    ports:
+      - "4382:4382" # Main Controller
+      - "4390:4390" # Hardware Emulator
+      - "8000:8000" # Service Center
+      - "10000:10000" # Testing Interface
+      - "27018:27018" # MongoDB
+    volumes:
+      - apis-mongodb-data:/app/mongodb/db
+      - apis-data:/data/db
+    environment:
+      - TZ=UTC
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:4382/" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+volumes:
+  apis-mongodb-data:
+    driver: local
+  apis-data:
+    driver: local

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# APIS Docker Entrypoint Script
+# Starts all APIS services in the correct order
+
+set -e
+
+echo "=========================================="
+echo "   APIS - Autonomous Power Interchange   "
+echo "=========================================="
+
+# Function to start a service in background
+start_service() {
+    local name=$1
+    local dir=$2
+    local cmd=$3
+    echo "[STARTING] $name..."
+    cd /app/$dir
+    eval "$cmd" &
+    sleep 2
+}
+
+# Start MongoDB
+echo "[STARTING] MongoDB..."
+mongod --dbpath /app/mongodb/db --port 27018 --bind_ip_all --fork --logpath /var/log/mongodb.log
+sleep 5
+
+# Start Service Center (bind to 0.0.0.0 for external access)
+start_service "Service Center" "apis-service_center" ". venv/bin/activate && python ./manage.py runserver --settings=config.settings.apis-service_center-demo 0.0.0.0:8000"
+
+# Start Hardware Emulator
+start_service "Hardware Emulator" "apis-emulator" ". venv/bin/activate && ./startEmul.py 4"
+
+# Start APIS Main instances (4 nodes for energy exchange)
+echo "[STARTING] APIS Main (4 nodes)..."
+cd /app/apis-main/exe
+sh start.sh &
+sleep 1
+sh start2.sh &
+sleep 1
+sh start3.sh &
+sleep 1
+sh start4.sh &
+sleep 2
+
+# Start CCC (Communication Coordinator)
+start_service "CCC" "apis-ccc/exe" "sh start.sh"
+
+# Start Log Service
+start_service "Log Service" "apis-log/exe" "sh start.sh"
+
+# Start Web Service
+start_service "Web Service" "apis-web/exe" "sh start.sh"
+
+# Start Main Controller
+start_service "Main Controller" "apis-main_controller" ". venv/bin/activate && ./startMain.py"
+
+# Start Tester (patch config to bind to 0.0.0.0 for external access)
+echo "[STARTING] Tester..."
+cd /app/apis-tester
+sed -i "s/my_host = 'localhost'/my_host = '0.0.0.0'/" config.py
+. venv/bin/activate && python ./startTester.py &
+sleep 2
+
+echo ""
+echo "=========================================="
+echo "   All APIS services started!            "
+echo "=========================================="
+echo ""
+echo "Available at:"
+echo "  - Main Controller:   http://localhost:4382/"
+echo "  - Hardware Emulator: http://localhost:4390/"
+echo "  - Service Center:    http://localhost:8000/static/ui_example/staff/visual.html"
+echo "  - Testing Interface: http://localhost:10000/"
+echo ""
+
+# Keep container running
+tail -f /dev/null


### PR DESCRIPTION
Closes #65

Added Docker support to make running APIS easier. Instead of manually installing Java, Python, MongoDB and building everything, you can now just run `docker-compose up`.

### What's included:
- Dockerfile with all dependencies (JDK 11, Python 3, MongoDB 4.4)
- docker-compose.yml for easy startup  
- Entrypoint script that starts all services in the right order
- .dockerignore for optimized builds

### How to test:
1. Make sure Docker is running
2. Run `docker-compose up` (takes ~7 mins first time)
3. Wait for "All APIS services started!" message
4. Open these URLs in your browser:
   - http://localhost:4382/ (Main Controller)
   - http://localhost:4390/ (Hardware Emulator)
   - http://localhost:10000/ (Testing Interface)
   - http://localhost:8000/static/ui_example/staff/visual.html (Service Center)

### Test results:
| Service | Port | Status |
|---------|------|--------|
| Main Controller | 4382 | ✓ Working |
| Hardware Emulator | 4390 | ✓ Working |
| Testing Interface | 10000 | ✓ Working |
| Service Center | 8000 | ⚠️ See note below |

### Known issue (not related to this PR):
The Service Center page loads but the UI doesn't render. This is a pre-existing bug in the `apis-service_center` repo where JavaScript files are served with `text/html` MIME type instead of `application/javascript`. The browser blocks them due to strict MIME checking. This happens with or without Docker - it's an upstream issue that should be fixed separately.

### Changes to apis-bom:
Had to roll back Vert.x from 4.4.6 to 3.9.16 because the GitHub repos (apis-ccc, apis-web, etc.) use older Vert.x APIs that were removed in v4. Without this fix, the Docker build fails with compilation errors.