### PR TITLE
Add spdx license identifiers

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+#
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
 /apis-*/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 All participants agree to abide by the [Code of Conduct](https://lfprojects.org/policies/code-of-conduct/).  Please contact [conduct@lfenergy.org](conduct@lfenergy.org) to report any
 violations or concerns.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Contributing to APIS
 
 Thank you for your interest in contributing to APIS! We welcome contributions from the community to help improve and grow this project.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # APIS Project Governance Policy
 
 ## Overview

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 GIT_BASE_URL=https://github.com/hyphae
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Copyright
 ## APIS (Autonomous Power Interchange System)
 ## © 2020 Sony Corporation 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,17 @@ Set up APIS for your neighborhood and bring energy independence to your communit
 ### 🎓 **For Researchers**
 Contribute to the future of distributed energy systems through APIS development and research.
 
+## Code Quality Tooling (Java)
+
+APIS Java modules may use standard code quality tools to keep the codebase
+consistent and modern.
+
+- **Checkstyle** is used to enforce Java coding conventions.
+- **Modernizer** helps detect usage of legacy Java APIs.
+- **OpenRewrite** can assist with automated refactoring and modernization.
+
+Configuration for these tools is typically done through Maven (`pom.xml`)
+and may vary between modules.
 ---
 
 *Made with ❤️ by the APIS Community - Powering the future, one battery at a time.*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # 🔋 APIS - Autonomous Power Interchange System
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hyphae/APIS/badge)](https://scorecard.dev/viewer/?uri=github.com/hyphae/APIS)
 

--- a/mongodb/db/.gitignore
+++ b/mongodb/db/.gitignore
@@ -1,2 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
 *
 !.gitignore

--- a/mongodb/start.sh
+++ b/mongodb/start.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
 echo 'call start.sh'
 
 cd $(dirname "${0}")

--- a/mongodb/stop.sh
+++ b/mongodb/stop.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
 echo 'call stop.sh'
 
 get_pids() {

--- a/runner.sh
+++ b/runner.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 
 if [ $# -ne 2 ] ; then
 	echo "usage: $0 <directory> <command>"


### PR DESCRIPTION
## Summary
- Add SPDX-License-Identifier: Apache-2.0 to all source file headers
- Use appropriate comment syntax for each file type (shell, YAML, Makefile, Markdown, gitignore)
- Add missing shebang lines to mongodb shell scripts for consistency

## Details
This addresses FOSSology compliance recommendations by adding standardized SPDX
license identifiers to file headers. The SPDX format enables automated license
detection tools to correctly identify file licensing.

Closes #59