### PR TITLE
Fix/makefile build ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,15 @@ apis-tester:
 
 build-apis-bom: apis-bom
 	cd apis-bom/ && make install
-build-apis-common:apis-common
+build-apis-common: apis-common build-apis-bom
 	cd apis-common/ && make install
-build-apis-main: apis-main
+build-apis-main: apis-main build-apis-common
 	cd apis-main/ && make package
-build-apis-ccc: apis-ccc
+build-apis-ccc: apis-ccc build-apis-common
 	cd apis-ccc/ && make package
-build-apis-log: apis-log
+build-apis-log: apis-log build-apis-common
 	cd apis-log/ && make package
-build-apis-web: apis-web
+build-apis-web: apis-web build-apis-common
 	cd apis-web/ && make package
 build-apis-emulator: apis-emulator
 	cd apis-emulator/ && sh venv.sh
@@ -93,7 +93,7 @@ clean-apis-service_center:
 clean-apis-tester:
 	cd apis-tester/ && rm -rf venv
 
-clean: clean-apis-bom clean-apis-common clean-apis-main clean-apis-ccc clean-apis-log clean-apis-web clean-apis-common clean-apis-bom clean-apis-emulator clean-apis-main_controller clean-apis-service_center clean-apis-tester
+clean: clean-apis-bom clean-apis-common clean-apis-main clean-apis-ccc clean-apis-log clean-apis-web clean-apis-emulator clean-apis-main_controller clean-apis-service_center clean-apis-tester
 
 
 run-apis-main-1:


### PR DESCRIPTION

## Description
This PR addresses a build failure that occurs when running `make build` on a clean environment or when using parallel execution (`make -j`). 

Currently, the `Makefile` treats sub-projects as independent targets, but they actually have strict compile-time dependencies (e.g., `apis-common` requires `apis-bom` to be installed first). Without enforcing this order, Maven fails to find the required artifacts in the local repository, causing the build to crash for new contributors.

**Changes made:**
1.  **Enforced Build Order:** Added explicit inter-target dependencies to the `Makefile`.
    * `build-apis-common` now strictly depends on `build-apis-bom`.
    * `build-apis-main`, `build-apis-ccc`, `build-apis-log`, and `build-apis-web` now depend on `build-apis-common`.
2.  **Cleaned up `clean` target:** Removed duplicate entries for `clean-apis-common` and `clean-apis-bom` in the `clean` command (Line 96), which were previously listed twice.

## Related Issue
Fixes #74 

