### PR TITLE
[Feature] Automated Multi-Service Deployment with Docker Compose and Production-Ready CI/CD Pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Docker build context exclusions
+
+# Git
+.git
+.github
+.gitignore
+
+# Documentation
+*.md
+docs/
+LICENSE
+NOTICE.md
+
+# MongoDB data (should use volumes, not baked in)
+mongodb/db/
+
+# IDE
+.vscode/
+.idea/
+*.iml
+
+# OS
+.DS_Store
+Thumbs.db

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,40 +2,48 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "add-license-1" ]
+    branches: [ "add-license-1", "main" ]
   pull_request:
-    branches: [ "add-license-1" ]
+    branches: [ "add-license-1", "main" ]
 
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
 
-    # - name: configure
-    #  run: ./configure
-
     - name: Install dependencies
       run: |
-        sudo apt install git
-        sudo apt install make
-        sudo apt install maven
-        sudo apt install groovy
-        sudo apt install python3-venv
-        sudo apt install python3-pip
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
-        echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
-        sudo apt install mongodb-org
+        sudo apt-get update
+        sudo apt-get install -y git make maven groovy python3-venv python3-pip curl
+        curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg
+        echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+        sudo apt-get update
+        sudo apt-get install -y mongodb-org
 
     - name: Build
       run: make build
-      
+
     - name: Run
-      run: make run
+      run: |
+        make run
+        sleep 30
+
+    - name: Health check
+      run: |
+        echo "Checking service health..."
+        curl -sf http://localhost:4382/ > /dev/null && echo "✓ Main Controller (4382) is up" || echo "✗ Main Controller (4382) is down"
+        curl -sf http://localhost:4390/ > /dev/null && echo "✓ Emulator (4390) is up" || echo "✗ Emulator (4390) is down"
+        curl -sf http://localhost:10000/ > /dev/null && echo "✓ Tester (10000) is up" || echo "✗ Tester (10000) is down"
+        curl -sf http://localhost:8000/static/ui_example/staff/visual.html > /dev/null && echo "✓ Service Center (8000) is up" || echo "✗ Service Center (8000) is down"
+        # Fail the job if the main services are not responding
+        curl -sf http://localhost:4382/ > /dev/null
+        curl -sf http://localhost:4390/ > /dev/null
 
     - name: Stop
+      if: always()
       run: make stop
 
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -29,7 +29,28 @@ jobs:
     - name: Run
       run: |
         make run
-        sleep 30
+
+        wait_for_url() {
+            local url="$1"
+            local name="$2"
+            local attempts=18
+            local delay=5
+
+            for ((i=1; i<=attempts; i++)); do
+                if curl -sf "$url" > /dev/null; then
+                    echo "✓ $name is ready"
+                    return 0
+                fi
+                echo "Waiting for $name ($url) to become ready... attempt $i/$attempts"
+                sleep "$delay"
+            done
+
+            echo "✗ Timed out waiting for $name ($url)"
+            return 1
+        }
+
+        wait_for_url "http://localhost:4382/" "Main Controller (4382)"
+        wait_for_url "http://localhost:4390/" "Emulator (4390)"
 
     - name: Health check
       run: |
@@ -38,9 +59,11 @@ jobs:
         curl -sf http://localhost:4390/ > /dev/null && echo "✓ Emulator (4390) is up" || echo "✗ Emulator (4390) is down"
         curl -sf http://localhost:10000/ > /dev/null && echo "✓ Tester (10000) is up" || echo "✗ Tester (10000) is down"
         curl -sf http://localhost:8000/static/ui_example/staff/visual.html > /dev/null && echo "✓ Service Center (8000) is up" || echo "✗ Service Center (8000) is down"
-        # Fail the job if the main services are not responding
+        # Fail the job if any service is not responding
         curl -sf http://localhost:4382/ > /dev/null
         curl -sf http://localhost:4390/ > /dev/null
+        curl -sf http://localhost:10000/ > /dev/null
+        curl -sf http://localhost:8000/static/ui_example/staff/visual.html > /dev/null
 
     - name: Stop
       if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Docker Compose for APIS (Autonomous Power Interchange System)
+#
+# Usage:
+#   docker compose up --build        # Build from source and start
+#   docker compose up -d             # Start in detached mode
+#   docker compose down              # Stop all services
+#   docker compose logs -f apis      # Follow APIS logs
+
+services:
+  mongodb:
+    image: mongo:6.0
+    container_name: apis-mongodb
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  apis:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: apis-app
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    ports:
+      - "4382:4382"
+      - "4390:4390"
+      - "8000:8000"
+      - "10000:10000"
+    environment:
+      - MONGODB_HOST=mongodb
+      - MONGODB_PORT=27017
+    restart: unless-stopped
+
+volumes:
+  mongodb_data:
+    driver: local

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Multi-stage Dockerfile for APIS (Autonomous Power Interchange System)
+# Builds all services from source for full reproducibility.
+
+# ==============================================================================
+# Stage 1: Builder - Compile Java services and prepare Python virtual environments
+# ==============================================================================
+FROM ubuntu:20.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    make \
+    maven \
+    groovy \
+    python3-venv \
+    python3-pip \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Clone and build all sub-repositories using the Makefile orchestrator
+COPY Makefile runner.sh ./
+
+# Clone all repositories
+RUN make apis-bom apis-common apis-main apis-ccc apis-log apis-web \
+    apis-emulator apis-main_controller apis-service_center apis-tester
+
+# Build Java dependencies first (order matters)
+RUN cd apis-bom && make install
+RUN cd apis-common && make install
+
+# Build Java services (produces fat JARs)
+RUN cd apis-main && make package
+RUN cd apis-ccc && make package
+RUN cd apis-log && make package
+RUN cd apis-web && make package
+
+# Build Python services (create virtual environments)
+RUN cd apis-emulator && sh venv.sh
+RUN cd apis-main_controller && sh venv.sh
+RUN cd apis-service_center && sh venv.sh && sh initdb.sh
+RUN cd apis-tester && sh venv.sh
+
+# ==============================================================================
+# Stage 2: Runtime - Lean image with only what's needed to run
+# ==============================================================================
+FROM ubuntu:20.04 AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    default-jre-headless \
+    python3 \
+    python3-venv \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /APIS
+
+# Copy built artifacts from builder
+COPY --from=builder /build/apis-main /APIS/apis-main
+COPY --from=builder /build/apis-ccc /APIS/apis-ccc
+COPY --from=builder /build/apis-log /APIS/apis-log
+COPY --from=builder /build/apis-web /APIS/apis-web
+COPY --from=builder /build/apis-emulator /APIS/apis-emulator
+COPY --from=builder /build/apis-main_controller /APIS/apis-main_controller
+COPY --from=builder /build/apis-service_center /APIS/apis-service_center
+COPY --from=builder /build/apis-tester /APIS/apis-tester
+
+# Copy orchestration files
+COPY Makefile runner.sh mongodb/ /APIS/
+COPY mongodb/ /APIS/mongodb/
+
+# Fix MongoDB port in service_center demo settings (27018 -> 27017)
+RUN if [ -f /APIS/apis-service_center/config/settings/apis-service_center-demo.py ]; then \
+    sed -i 's/27018/27017/g' /APIS/apis-service_center/config/settings/apis-service_center-demo.py; \
+    fi
+
+# Expose all service ports
+EXPOSE 4382 4390 8000 10000
+
+# Health check against the main controller
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:4382/ || exit 1
+
+# Entrypoint script to start all services
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,12 +74,15 @@ COPY --from=builder /build/apis-tester /APIS/apis-tester
 
 # Copy orchestration files
 COPY Makefile runner.sh mongodb/ /APIS/
-COPY mongodb/ /APIS/mongodb/
 
 # Fix MongoDB port in service_center demo settings (27018 -> 27017)
-RUN if [ -f /APIS/apis-service_center/config/settings/apis-service_center-demo.py ]; then \
-    sed -i 's/27018/27017/g' /APIS/apis-service_center/config/settings/apis-service_center-demo.py; \
-    fi
+RUN for settings_file in \
+        /APIS/apis-service_center/config/settings/apis_service_center_demo.py \
+        /APIS/apis-service_center/config/settings/apis-service_center-demo.py; do \
+    if [ -f "$settings_file" ]; then \
+        sed -i 's/27018/27017/g' "$settings_file"; \
+    fi; \
+    done
 
 # Expose all service ports
 EXPOSE 4382 4390 8000 10000

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -17,7 +17,7 @@ echo "========================================"
 echo "[1/8] Starting apis-service_center on port 8000..."
 cd "$APIS_DIR/apis-service_center"
 . venv/bin/activate
-python3 ./manage.py runserver --settings=config.settings.apis-service_center-demo 0.0.0.0:8000 &
+python3 -m gunicorn config.wsgi:application --bind 0.0.0.0:8000 --env DJANGO_SETTINGS_MODULE=config.settings.apis_service_center_demo &
 deactivate 2>/dev/null || true
 
 # Start apis-emulator
@@ -102,5 +102,19 @@ echo " Tester:       http://localhost:10000"
 echo " Admin Panel:  http://localhost:8000/static/ui_example/staff/visual.html"
 echo "========================================"
 
-# Keep the container running and forward signals
-wait
+terminate_children() {
+    local pids
+    pids="$(jobs -pr)"
+    if [ -n "$pids" ]; then
+        kill -TERM $pids 2>/dev/null || true
+    fi
+}
+
+trap 'terminate_children; wait || true; exit 143' TERM INT
+
+# Keep the container running, forward signals, and exit if any service stops
+wait -n
+status=$?
+terminate_children
+wait || true
+exit "$status"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Entrypoint script for APIS container
+# Starts all services and keeps the container running
+
+set -e
+
+APIS_DIR="/APIS"
+cd "$APIS_DIR"
+
+echo "========================================"
+echo " APIS - Autonomous Power Interchange System"
+echo " Starting all services..."
+echo "========================================"
+
+# Start apis-service_center (Django)
+echo "[1/8] Starting apis-service_center on port 8000..."
+cd "$APIS_DIR/apis-service_center"
+. venv/bin/activate
+python3 ./manage.py runserver --settings=config.settings.apis-service_center-demo 0.0.0.0:8000 &
+deactivate 2>/dev/null || true
+
+# Start apis-emulator
+echo "[2/8] Starting apis-emulator on port 4390..."
+cd "$APIS_DIR/apis-emulator"
+. venv/bin/activate
+python3 ./startEmul.py 4 &
+deactivate 2>/dev/null || true
+
+# Start apis-main instances (4 nodes)
+echo "[3/8] Starting apis-main (4 instances)..."
+cd "$APIS_DIR/apis-main/exe"
+java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo \
+    -Djava.util.logging.config.file=./logging.properties \
+    -Dvertx.hazelcast.config=./cluster.xml \
+    -jar ../target/apis-main-3.0.0-fat.jar -conf ./config.json \
+    -cluster -cluster-host 127.0.0.1 &
+
+java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo \
+    -Djava.util.logging.config.file=./logging.properties \
+    -Dvertx.hazelcast.config=./cluster.xml \
+    -jar ../target/apis-main-3.0.0-fat.jar -conf ./config2.json \
+    -cluster -cluster-host 127.0.0.1 &
+
+java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo \
+    -Djava.util.logging.config.file=./logging.properties \
+    -Dvertx.hazelcast.config=./cluster.xml \
+    -jar ../target/apis-main-3.0.0-fat.jar -conf ./config3.json \
+    -cluster -cluster-host 127.0.0.1 &
+
+java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo \
+    -Djava.util.logging.config.file=./logging.properties \
+    -Dvertx.hazelcast.config=./cluster.xml \
+    -jar ../target/apis-main-3.0.0-fat.jar -conf ./config4.json \
+    -cluster -cluster-host 127.0.0.1 &
+
+# Start apis-ccc
+echo "[4/8] Starting apis-ccc..."
+cd "$APIS_DIR/apis-ccc/exe"
+java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo \
+    -Djava.util.logging.config.file=./logging.properties \
+    -Dvertx.hazelcast.config=./cluster.xml \
+    -jar ../target/apis-ccc-3.0.0-fat.jar -conf ./config.json \
+    -cluster -cluster-host 127.0.0.1 &
+
+# Start apis-log
+echo "[5/8] Starting apis-log..."
+cd "$APIS_DIR/apis-log/exe"
+java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo \
+    -Djava.util.logging.config.file=./logging.properties \
+    -jar ../target/apis-log-3.0.0-fat.jar -conf ./config.json &
+
+# Start apis-web
+echo "[6/8] Starting apis-web..."
+cd "$APIS_DIR/apis-web/exe"
+java -Djava.net.preferIPv4Stack=true -Duser.timezone=Asia/Tokyo \
+    -Djava.util.logging.config.file=./logging.properties \
+    -Dvertx.hazelcast.config=./cluster.xml \
+    -jar ../target/apis-web-3.0.0-fat.jar run \
+    jp.co.sony.csl.dcoes.apis.tools.web.util.Starter \
+    --conf ./config.json --cluster --cluster-host 127.0.0.1 &
+
+# Start apis-main_controller
+echo "[7/8] Starting apis-main_controller on port 4382..."
+cd "$APIS_DIR/apis-main_controller"
+. venv/bin/activate
+python3 ./startMain.py &
+deactivate 2>/dev/null || true
+
+# Start apis-tester
+echo "[8/8] Starting apis-tester on port 10000..."
+cd "$APIS_DIR/apis-tester"
+. venv/bin/activate
+python3 ./startTester.py &
+deactivate 2>/dev/null || true
+
+echo "========================================"
+echo " All services started!"
+echo " Dashboard:    http://localhost:4382"
+echo " Emulator:     http://localhost:4390"
+echo " Tester:       http://localhost:10000"
+echo " Admin Panel:  http://localhost:8000/static/ui_example/staff/visual.html"
+echo "========================================"
+
+# Keep the container running and forward signals
+wait

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,112 @@
+## 🛠️ Development Guide
+
+This guide covers local development setup for contributors.
+
+### Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| **Docker** | 20.10+ | Container runtime |
+| **Docker Compose** | v2.0+ | Service orchestration |
+| **Git** | 2.30+ | Version control |
+
+Optional (for native development without Docker):
+- **JDK** 11+ and **Maven** 3.6+
+- **Groovy** 2.5+
+- **Python** 3.8+ with `python3-venv`
+- **MongoDB** 6.0+
+
+---
+
+### Running with Docker Compose
+
+```bash
+# Build from source and start all services
+docker compose up --build
+
+# Run in detached mode
+docker compose up --build -d
+
+# View logs
+docker compose logs -f apis
+
+# Stop everything
+docker compose down
+
+# Stop and clean volumes
+docker compose down -v
+```
+
+### Running Natively
+
+See [Host Installation](INSTALL_HOST.md) for native setup instructions.
+
+```bash
+# Build all components
+make build
+
+# Start all services (requires MongoDB running on port 27017)
+make run
+
+# Stop all services
+make stop
+```
+
+---
+
+### Project Architecture
+
+```
+APIS/                          # Orchestrator repository
+├── Makefile                   # Build/run/stop orchestrator
+├── docker-compose.yml         # Docker Compose configuration
+├── docker/
+│   ├── Dockerfile             # Multi-stage build
+│   └── entrypoint.sh          # Service startup script
+├── mongodb/                   # MongoDB scripts
+├── apis-bom/                  # [Java] Bill of Materials
+├── apis-common/               # [Java] Shared libraries
+├── apis-main/                 # [Java/Vert.x] Core energy exchange engine
+├── apis-ccc/                  # [Java/Vert.x] Cluster coordination
+├── apis-log/                  # [Java] Log aggregation
+├── apis-web/                  # [Java/Vert.x] Web API layer
+├── apis-emulator/             # [Python] Hardware simulator
+├── apis-main_controller/      # [Python] Dashboard UI
+├── apis-service_center/       # [Python/Django] Admin panel
+└── apis-tester/               # [Python] Test framework
+```
+
+### Service Ports
+
+| Port | Service | Protocol |
+|------|---------|----------|
+| 4382 | Main Controller | HTTP |
+| 4390 | Emulator | HTTP |
+| 8000 | Service Center | HTTP |
+| 10000 | Tester | HTTP |
+| 27017 | MongoDB | TCP |
+
+### Build Order
+
+Java services must be built in order:
+
+1. `apis-bom` (Maven BOM — install first)
+2. `apis-common` (Shared library — install second)
+3. `apis-main`, `apis-ccc`, `apis-log`, `apis-web` (Can build in parallel)
+4. Python services (`apis-emulator`, `apis-main_controller`, `apis-service_center`, `apis-tester`) can build in parallel
+
+---
+
+### Troubleshooting
+
+**Port conflicts:** Ensure ports 4382, 4390, 8000, 10000, and 27017 are not in use.
+
+**Docker build fails:** Clear Docker cache and rebuild:
+```bash
+docker compose build --no-cache
+```
+
+**Services not connecting:** Services may take 30-60 seconds to fully start due to Hazelcast cluster formation. Check logs:
+```bash
+docker compose logs -f apis
+```

--- a/docs/INSTALL_DOCKER.md
+++ b/docs/INSTALL_DOCKER.md
@@ -1,6 +1,44 @@
 ## 💻 Docker Installation & Troubleshooting Guide
 
-### 1. Environment Setup
+### Quick Start (Recommended)
+
+The fastest way to get APIS running is with Docker Compose, which handles MongoDB and all services automatically:
+
+```bash
+# Clone the repository
+git clone https://github.com/hyphae/APIS.git
+cd APIS
+
+# Build and start everything
+docker compose up --build
+```
+
+**That's it!** Once the build completes, access the web interfaces:
+
+| Service | URL |
+|---------|-----|
+| **Main Controller** | http://localhost:4382 |
+| **Emulator** | http://localhost:4390 |
+| **Tester** | http://localhost:10000 |
+| **Service Center** | http://localhost:8000/static/ui_example/staff/visual.html |
+
+To stop all services:
+```bash
+docker compose down
+```
+
+To stop and remove all data (including MongoDB):
+```bash
+docker compose down -v
+```
+
+---
+
+### Manual Setup (Alternative)
+
+If you prefer manual control over the environment, follow the steps below.
+
+#### 1. Environment Setup
 
 The environment is containerized to ensure consistency and avoid host machine dependency issues. You must map the required ports during the initial run to access the web interfaces later.
 

--- a/mongodb/start.sh
+++ b/mongodb/start.sh
@@ -4,6 +4,6 @@
 echo 'call start.sh'
 
 cd $(dirname "${0}")
-mongod --dbpath ./db --port 27018 --bind_ip_all
+mongod --dbpath ./db --port 27017 --bind_ip_all
 
 echo '... done'

--- a/mongodb/stop.sh
+++ b/mongodb/stop.sh
@@ -4,7 +4,7 @@
 echo 'call stop.sh'
 
 get_pids() {
- ps -f -U $(whoami) | grep mongod | grep 'port 27018' | while read _USER_ _PID_ _OTHERS_ ; do
+ ps -f -U $(whoami) | grep mongod | grep 'port 27017' | while read _USER_ _PID_ _OTHERS_ ; do
   echo $_PID_
  done
 }


### PR DESCRIPTION
Adds reproducible Docker-based deployment, fixes the CI/CD pipeline, and standardizes the MongoDB port configuration. This resolves the key barrier for new contributors who currently must follow a 10+ step manual Docker setup.

Closes #98

**Changes**
**Docker Compose Deployment**
- **`docker/Dockerfile`** - Multi-stage build (builder + runtime) that clones all sub-repos, builds Java services with Maven, sets up Python venvs, and produces a lean runtime image
- **`docker-compose.yml`**- Orchestrates MongoDB 6.0 (with health checks) + APIS app service. Single command: `docker compose up --build`
- **`docker/entrypoint.sh`** - Starts all 8 services (4x apis-main, apis-ccc, apis-log, apis-web, apis-emulator, apis-main_controller, apis-service_center, apis-tester) in correct order
- **`.dockerignore`** - Optimizes build context by excluding .git, docs, IDE files

**CI/CD Pipeline Fixes**
- Retargeted workflow triggers to include `main` branch (was only `add-license-1`)
- Upgraded runner from `ubuntu-20.04` to `ubuntu-22.04`
- Upgraded MongoDB from 4.0 (deprecated bionic repo) to 6.0 with proper GPG key
- Replaced individual `apt install` with single `apt-get install -y` call
- Added **post-deployment health checks** - validates HTTP 200 on ports 4382, 4390, 10000, 8000
- Added `if: always()` on stop step to ensure cleanup on failure

**MongoDB Port Standardization**
- Changed `mongodb/start.sh` from port 27018 → **27017**
- Changed `mongodb/stop.sh` grep pattern from 27018 → **27017**
- Dockerfile auto-fixes `apis-service_center-demo.py` settings (27018 → 27017)

**Documentation**
- Updated `docs/INSTALL_DOCKER.md` with Docker Compose quick start section
- Added `docs/DEVELOPMENT.md` with architecture overview, build order, and troubleshooting

**Testing**
Tested locally with Docker on Windows:
-  MongoDB starts on port 27017 and is accessible (`apis_demo` database populated)
- All 14 processes running (4x apis-main, apis-ccc, apis-log, apis-web, emulator, main_controller, service_center, tester, MongoDB)
- HTTP 200 on all 4 web endpoints (4382, 4390, 10000, 8000)
- Service Center admin panel accessible at `/static/ui_example/staff/visual.html`

**Impact**
| Area | Before | After |
|---|---|---|
| New contributor setup | Manual 10+ step Docker process | Single `docker compose up --build` |
| Build reproducibility | Opaque pre-built image | Fully from-source Dockerfile in repo |
| CI/CD | Wrong branch, no tests, deprecated MongoDB | Runs on PRs with health validation |
| MongoDB port | Inconsistent (27018 in scripts, 27017 in docs) | Standardized to 27017 everywhere |